### PR TITLE
Add pages with final message when user confirms if they kept their promise

### DIFF
--- a/app/controllers/promises_controller.rb
+++ b/app/controllers/promises_controller.rb
@@ -24,4 +24,12 @@ class PromisesController < ApplicationController
   def promise_params
     params.require(:promise).permit(:text, :end_datetime, :interval, :punishment)
   end
+
+  def congrats
+    @promise = Promise.find(params[:id])
+  end
+
+  def punishment
+    @promise = Promise.find(params[:id])
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,7 +12,7 @@
   <body>
   <% if signed_in? %>
   Logged in as: <%= current_user.email %>
-  <%= button_to 'Log out', sign_out_path, method: :delete %>
+  <%= button_to 'Sign out', sign_out_path, method: :delete %>
 <% end %>
 
 <div id="flash">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,10 +11,8 @@
 
   <body>
   <% if signed_in? %>
-  Signed in as: <%= current_user.email %>
-  <%= button_to 'Sign out', sign_out_path, method: :delete %>
-<% else %>
-  <%= link_to 'Sign in', sign_in_path %>
+  Logged in as: <%= current_user.email %>
+  <%= button_to 'Log out', sign_out_path, method: :delete %>
 <% end %>
 
 <div id="flash">

--- a/app/views/promises/congrats.html.erb
+++ b/app/views/promises/congrats.html.erb
@@ -1,0 +1,7 @@
+<%= form_for @promise do |f| %>
+  <h1>Congratulations <%= current_user.firstname %>, you kept your promise:</h1>
+  <h2>I promise <%=@promise.text%></h2>
+  <h1>You're awesome!</h1>
+  <h2>Would you like to make a new promise?</h2>
+<% end %>
+<%= link_to 'create a new promise', new_promise_path %>

--- a/app/views/promises/index.html.erb
+++ b/app/views/promises/index.html.erb
@@ -1,5 +1,5 @@
-<h1>Promises#index</h1>
-<p>Find me in app/views/promises/index.html.erb</p>
+<h1>Hi <%= current_user.firstname %>!</h1>
+<h2>Here are your promises:</h1>
 
 <ul>
     <% @promises.each do |promise| %>

--- a/app/views/promises/punishment.html.erb
+++ b/app/views/promises/punishment.html.erb
@@ -1,0 +1,7 @@
+<%= form_for @promise do |f| %>
+  <h1>Oh no <%= current_user.firstname %>! You broke your promise:</h1>
+  <h2>I promise <%=@promise.text%></h2>
+  <h1>Time for your punishment... Here's what you're going to do: </h1>
+  <h2>If I break my promise <%=@promise.punishment%></h2>
+<% end %>
+<%= link_to 'create a new promise', new_promise_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,8 +15,10 @@ Rails.application.routes.draw do
   delete "/sign_out" => "clearance/sessions#destroy", as: "sign_out"
   get "/sign_up" => "clearance/users#new", as: "sign_up"
   get 'home/index'
+  get "promises/:id/congrats" => "promises#congrats"
+  get "promises/:id/punishment" => "promises#punishment"
 
   root 'promises#index'
-  
+
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION
- Add to routes.rb actions to get /promises/:id/congrats (for YES, kept promise) and action /punishment for NO
- In promises controller, added actions congrats and punishment
- Created views in views/promises/congrats and views/promises/punishment
- End result: congrats shows on url: /promises/[PROMISE_ID]/congrats
  and punishment shows on url: /promises/[PROMISE_ID]/punishment
Also did housekeeping: 
- Removed in the "sign in" link at top of sign in / sign up pages (not required, had been put there by clearance)
- Changed the message on promises/index page, so that it greets the user
