### PR TITLE
Refactor: remove form from congrats and punishment pages

### DIFF
--- a/app/views/promises/congrats.html.erb
+++ b/app/views/promises/congrats.html.erb
@@ -1,7 +1,7 @@
-<%= form_for @promise do |f| %>
-  <h1>Congratulations <%= current_user.firstname %>, you kept your promise:</h1>
-  <h2>I promise <%=@promise.text%></h2>
-  <h1>You're awesome!</h1>
-  <h2>Would you like to make a new promise?</h2>
-<% end %>
+
+<h1>Congratulations <%= current_user.firstname %>, you kept your promise:</h1>
+<h2>I promise <%=@promise.text%></h2>
+<h1>You're awesome!</h1>
+<h2>Would you like to make a new promise?</h2>
+
 <%= link_to 'create a new promise', new_promise_path %>

--- a/app/views/promises/punishment.html.erb
+++ b/app/views/promises/punishment.html.erb
@@ -1,7 +1,7 @@
-<%= form_for @promise do |f| %>
-  <h1>Oh no <%= current_user.firstname %>! You broke your promise:</h1>
-  <h2>I promise <%=@promise.text%></h2>
-  <h1>Time for your punishment... Here's what you're going to do: </h1>
-  <h2>If I break my promise <%=@promise.punishment%></h2>
-<% end %>
+
+<h1>Oh no <%= current_user.firstname %>! You broke your promise:</h1>
+<h2>I promise <%=@promise.text%></h2>
+<h1>Time for your punishment... Here's what you're going to do: </h1>
+<h2>If I break my promise <%=@promise.punishment%></h2>
+
 <%= link_to 'create a new promise', new_promise_path %>


### PR DESCRIPTION
- Updates made to files:
  app/views/promises/congrats
  app/views/promises/punishment
- These files had an error on them - they contained a form that is not required. Now removed.