### PR TITLE
Temporary solution: Put calendar back to text input 

### DIFF
--- a/app/views/promises/new.html.erb
+++ b/app/views/promises/new.html.erb
@@ -8,7 +8,7 @@
   <%= form.text_field :interval, :value => '1 day'%>
   <br>
   <%= form.label :end_datetime, 'End date:'%>
-  <%= form.date_select(:end_datetime, order: [:day, :month, :year], start_year: Date.today.year - 0, end_year: Date.today.year + 5) %>
+  <%= form.text_field :end_datetime, :value => '31/01/2019'%>
   <br>
   <%= form.label :punishment, 'If I break my promise...' %>
   <%= form.text_field :punishment %>


### PR DESCRIPTION
Calendar with drop down menus didn't work - didn't add end date to promises database
This is a temporary solution to enable integration testing to proceed
Working on final solution