### PR TITLE
Add edit promises feature

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,3 +32,7 @@ Style/FrozenStringLiteralComment:
 
 Metrics/LineLength:
   Enabled: false
+
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*.rb'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,8 +64,6 @@ GEM
     bindex (0.8.1)
     bootsnap (1.4.5)
       msgpack (~> 1.0)
-    bootstrap-datepicker-rails (1.8.0.1)
-      railties (>= 3.0)
     builder (3.2.3)
     byebug (11.0.1)
     capybara (2.18.0)
@@ -272,7 +270,6 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap (>= 1.4.2)
-  bootstrap-datepicker-rails
   byebug
   capybara (~> 2.13)
   clearance

--- a/app/controllers/promises_controller.rb
+++ b/app/controllers/promises_controller.rb
@@ -31,4 +31,16 @@ class PromisesController < ApplicationController
   def punishment
     @promise = Promise.find(params[:id])
   end
+
+  def edit
+    @promise = Promise.find(params[:id])
+  end
+
+  def update
+    @promise = Promise.find(params[:id])
+    permitted_columns = params.require(:promise).permit(:text, :interval, :end_datetime, :punishment)
+    @promise.update_attributes(permitted_columns)
+
+    redirect_to promises_path
+  end
 end

--- a/app/controllers/promises_controller.rb
+++ b/app/controllers/promises_controller.rb
@@ -39,7 +39,7 @@ class PromisesController < ApplicationController
   def update
     @promise = Promise.find(params[:id])
     permitted_columns = params.require(:promise).permit(:text, :interval, :end_datetime, :punishment)
-    @promise.update_attributes(permitted_columns)
+    @promise.update(permitted_columns)
 
     redirect_to promises_path
   end

--- a/app/views/promises/edit.html.erb
+++ b/app/views/promises/edit.html.erb
@@ -1,0 +1,18 @@
+<h2>Edit your promise</h2>
+
+<%= form_for :promise do |form| %>
+  <%= form.label :text, 'I promise...' %>
+  <%= form.text_field :text %>
+  <br>
+  <%= form.label :interval, 'How often do you want to receive reminder?' %>
+  <%= form.text_field :interval, :value => '1 day'%>
+  <br>
+  <%= form.label :end_datetime, 'End date:'%>
+  <%= form.date_field :end_datetime %>
+  <br>
+  <%= form.label :punishment, 'If I break my promise...' %>
+  <%= form.text_field :punishment %>
+  <br>
+  <%= form.submit %>
+<% end %>
+<%= link_to 'Back', promises_path %>

--- a/app/views/promises/index.html.erb
+++ b/app/views/promises/index.html.erb
@@ -4,6 +4,7 @@
 <ul>
     <% @promises.each do |promise| %>
     <li><%= promise.text %></li>
+    <%= link_to 'edit', edit_promise_path(promise) %>
     <% end %>
 </ul>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
   get 'home/index'
   get "promises/:id/congrats" => "promises#congrats"
   get "promises/:id/punishment" => "promises#punishment"
+  post "promises/:id/edit" => "promises#update"
 
   root 'promises#index'
 

--- a/spec/controllers/promises_controller_spec.rb
+++ b/spec/controllers/promises_controller_spec.rb
@@ -16,9 +16,7 @@ RSpec.describe PromisesController, type: :controller do
       sign_out
     end
   end
-end
 
-RSpec.describe PromisesController, type: :controller do
   describe 'fetching promises' do
     it 'only fetch promises created by current user' do
       sign_in
@@ -38,9 +36,7 @@ RSpec.describe PromisesController, type: :controller do
       sign_out
     end
   end
-end
 
-RSpec.describe PromisesController, type: :controller do
   describe 'POST #create' do
     it "save a new entry to the 'promise' database" do
       sign_in

--- a/spec/features/edit_post_spec.rb
+++ b/spec/features/edit_post_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.feature "Updating posts", type: :feature do
+  scenario "User updates post" do
+    sign_in
+    click_link "create a new promise"
+    fill_in "I promise...", with: 'test promise'
+    fill_in "How often do you want to receive reminder?", with: '1 day'
+    fill_in "End date:", with: '31/01/2019'
+    fill_in "If I break my promise...", with: 'test punishment'
+    click_button "Submit"
+    visit current_path
+    expect(page).to have_content("test promise")
+    click_link "edit"
+    fill_in "I promise...", with: 'edited promise'
+    fill_in "How often do you want to receive reminder?", with: '1 day'
+    fill_in "End date:", with: '31/01/2019'
+    fill_in "If I break my promise...", with: 'test punishment'
+    click_button "Save Promise"
+    visit current_path
+    expect(page).to have_content("edited promise")
+  end
+end

--- a/spec/features/edit_post_spec.rb
+++ b/spec/features/edit_post_spec.rb
@@ -1,23 +1,23 @@
 require 'rails_helper'
 
-RSpec.feature "Updating posts", type: :feature do
-  scenario "User updates post" do
+RSpec.feature 'Updating posts', type: :feature do
+  scenario 'User updates post' do
     sign_in
-    click_link "create a new promise"
-    fill_in "I promise...", with: 'test promise'
-    fill_in "How often do you want to receive reminder?", with: '1 day'
-    fill_in "End date:", with: '31/01/2019'
-    fill_in "If I break my promise...", with: 'test punishment'
-    click_button "Submit"
+    click_link 'create a new promise'
+    fill_in 'I promise...', with: 'test promise'
+    fill_in 'How often do you want to receive reminder?', with: '1 day'
+    fill_in 'End date:', with: '31/01/2019'
+    fill_in 'If I break my promise...', with: 'test punishment'
+    click_button 'Submit'
     visit current_path
-    expect(page).to have_content("test promise")
-    click_link "edit"
-    fill_in "I promise...", with: 'edited promise'
-    fill_in "How often do you want to receive reminder?", with: '1 day'
-    fill_in "End date:", with: '31/01/2019'
-    fill_in "If I break my promise...", with: 'test punishment'
-    click_button "Save Promise"
+    expect(page).to have_content('test promise')
+    click_link 'edit'
+    fill_in 'I promise...', with: 'edited promise'
+    fill_in 'How often do you want to receive reminder?', with: '1 day'
+    fill_in 'End date:', with: '31/01/2019'
+    fill_in 'If I break my promise...', with: 'test punishment'
+    click_button 'Save Promise'
     visit current_path
-    expect(page).to have_content("edited promise")
+    expect(page).to have_content('edited promise')
   end
 end


### PR DESCRIPTION
- Add 'edit' link to promises/index 
- Add promises/edit view, which is similar to promises/new view
- Add 2 methods to promises controller - edit and update (both are required for this to work)
- Add route to config/routes: post "promises/:id/edit" => "promises#update"