### PR TITLE
Shortened text on congrats/punishment pages to avoid overlap ...

### DIFF
--- a/app/views/promises/congrats.html.erb
+++ b/app/views/promises/congrats.html.erb
@@ -2,10 +2,9 @@
 <link href="https://fonts.googleapis.com/css?family=Pacifico&display=swap" rel="stylesheet">
 
 <div class="congratz-container">
-  <h2 align="center">Congratulations <%= current_user.firstname %>, you kept your promise :</h2>
+  <h2 align="center">Congrats <%= current_user.firstname %>, you kept your promise:</h2>
   <h3 align="center">I promise <%=@promise.text%></h3>
   <h2 align="center">You're awesome!</h2>
-  <h3 align="center">Would you like to make a new promise? </h2>
    <div class="link-to-text">
    <%= link_to 'create a new promise', new_promise_path%>
    </div>

--- a/app/views/promises/punishment.html.erb
+++ b/app/views/promises/punishment.html.erb
@@ -1,8 +1,7 @@
 <%= image_tag('giphy.gif', draggable: "true", id: "drag1", :size => "1000x300",class: "center-block")%>
 <div class="punishment-container">
-<h2>Oh no, <%= current_user.firstname %>! You broke your promise:</h2>
-<h3>I promise <%=@promise.text%></h3>
-<h2>Here's your chosen punishment:</h2>
+<h2>Oh no, <%= current_user.firstname %>! You broke your promise!</h2>
+<h2>Remember your punishment:</h2>
 <h3>If I break my promise <%=@promise.punishment%></h3>
  <div class="link-to-text1">
 <%= link_to 'create a new promise', new_promise_path ,class: 'link-to-text1'%>


### PR DESCRIPTION
… with cactus pictures on bottom of page.

Shorted the text that appears on pages:
- app/views/congrats
- app/views/punishment

Checks:
- Checked visually on screen, looks OK
- rspec still passes